### PR TITLE
[#10] add set -x to bash scripts verbose is set

### DIFF
--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -235,6 +235,14 @@ func (chunk *ExecutableChunk) WriteBashScript(basedir string, script_name string
 		return err
 	}
 
+	// enable verbose mode (set -x) when verbose flag is set
+	if chunk.Context.Cfg.Verbose {
+		_, err = writer.WriteString("set -x\n")
+		if err != nil {
+			return err
+		}
+	}
+
 	// the actual script the user wants to execute
 	for _, line := range chunk.Content {
 		_, err = writer.WriteString(line + "\n")

--- a/test/cases/verbose_set_x.md
+++ b/test/cases/verbose_set_x.md
@@ -1,0 +1,9 @@
+# Verbose Set -x Test Case
+
+This test verifies that `set -x` is added to bash scripts when verbose mode is enabled.
+
+```bash {"stage":"test", "runtime":"bash"}
+echo "Testing set -x functionality"
+TEST_VAR="verbose_test"
+echo "Variable value: $TEST_VAR"
+```

--- a/test/run.sh
+++ b/test/run.sh
@@ -91,6 +91,12 @@ for test_file in cases/*.md; do
             "./markdown-runner -d cases -f '.*'${test_file} 2>&1 | grep -E 'DRY-RUN.*|.*echo happy path'" || ((FAILED_TESTS++))
         run_test "Happy path test (${test_name}) should succeed" \
             "./markdown-runner cases -f '.*'${test_file}" || ((FAILED_TESTS++))
+    # The verbose_set_x test verifies set -x functionality
+    elif [ "${test_name}" == "verbose_set_x" ]; then
+        run_test "Verbose set -x test (${test_name}) should show command tracing with -v" \
+            "./markdown-runner -v cases -f '.*'${test_file} 2>&1 | grep -E '\\+ echo.*Testing set -x functionality'" || ((FAILED_TESTS++))
+        run_test "Non-verbose test (${test_name}) should not show command tracing without -v" \
+            "! ./markdown-runner cases -f '.*'${test_file} 2>&1 | grep -E '\\+ echo.*Testing set -x functionality'" || ((FAILED_TESTS++))
     else
         run_test "Test case ${test_name}" \
             "./markdown-runner cases -f '.*'${test_file}" || ((FAILED_TESTS++))


### PR DESCRIPTION
- When -v/--verbose flag is used, generated bash scripts now include 'set -x'
- Only affects bash runtime chunks, not individual command execution
- Maintains backward compatibility when verbose mode is not used